### PR TITLE
feat(ui): Add resume page

### DIFF
--- a/.changeset/cold-mails-raise.md
+++ b/.changeset/cold-mails-raise.md
@@ -1,0 +1,5 @@
+---
+'jakebrazelton-com': minor
+---
+
+feat: add resume page

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.36.1",
+    "@portabletext/svelte": "^2.0.0",
     "@sveltejs/adapter-vercel": "^3.0.2",
     "@sveltejs/kit": "^1.22.3",
     "@types/react": "^18.2.15",
@@ -65,6 +66,6 @@
   },
   "volta": {
     "node": "18.17.0",
-    "pnpm": "8.6.9"
+    "pnpm": "8.6.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ devDependencies:
   '@playwright/test':
     specifier: ^1.36.1
     version: 1.36.1
+  '@portabletext/svelte':
+    specifier: ^2.0.0
+    version: 2.0.0(svelte@4.1.1)
   '@sveltejs/adapter-vercel':
     specifier: ^3.0.2
     version: 3.0.2(@sveltejs/kit@1.22.3)
@@ -1120,6 +1123,27 @@ packages:
 
   /@polka/url@1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
+
+  /@portabletext/svelte@2.0.0(svelte@4.1.1):
+    resolution: {integrity: sha512-fyA2BFC4c/16PJxu1QpI8PC1W32TJjEPHRh69aW19OFYv5m4+7Gd4J4+Oq9C1FTKycNfcUTNaEik07KqhrLPfQ==}
+    peerDependencies:
+      svelte: ^3.47.0
+    dependencies:
+      '@portabletext/toolkit': 2.0.4
+      svelte: 4.1.1
+    dev: true
+
+  /@portabletext/toolkit@2.0.4:
+    resolution: {integrity: sha512-ZE+WntiZQ40vxMBu3/QXRbGjzL8/R2BOFgdf6danJOahvlL9lZ1/DDShyUsxNaAvoBarwGJtjuZVOcRJWcsVng==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+    dependencies:
+      '@portabletext/types': 2.0.5
+    dev: true
+
+  /@portabletext/types@2.0.5:
+    resolution: {integrity: sha512-AceKp/Y6UIzvUe/T675oPKlO2Dnt1BVIiUpwhcplPzLeYqaYaWYvb7ricVyWj7j0rukYRgBRQdrTBvgo9E1D+g==}
+    engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
     dev: true
 
   /@rexxars/react-json-inspector@8.0.1(react@18.2.0):

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  import ThemeSwitch from './ThemeSwitch.svelte';
+</script>
+
 <header
   class="supports-backdrop-blur:bg-background/60 sticky top-0 z-40 w-full border-b bg-background/95 shadow-sm backdrop-blur"
 >
@@ -10,6 +14,7 @@
     </a>
     <nav class="flex gap-4">
       <a href="/resume" class="text-lg font-medium hover:underline hover:text-purple-400">Resume</a>
+      <ThemeSwitch class="-mt-1" />
     </nav>
   </div>
 </header>

--- a/src/lib/components/ThemeSwitch.svelte
+++ b/src/lib/components/ThemeSwitch.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { fly } from 'svelte/transition';
+  import { Button } from '$components/ui/button';
+  import clsx from 'clsx';
+
+  let className: string | undefined | null = undefined;
+  export { className as class };
+
+  type Theme = 'light' | 'dark';
+
+  const dispatch = createEventDispatcher();
+  let currentTheme: Theme = 'light';
+
+  onMount(() => {
+    currentTheme = <Theme>localStorage.getItem('theme') ?? 'light';
+  });
+  const toggle = () => {
+    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('theme', currentTheme);
+    (document.body.parentNode as HTMLElement).classList.toggle('dark');
+    dispatch('change', { theme: currentTheme });
+  };
+</script>
+
+<Button
+  on:click={toggle}
+  type="button"
+  variant="secondary"
+  class={clsx('inline-flex items-center justify-center rounded-full bg-transparent p-2', className)}
+>
+  {#if currentTheme === 'dark'}
+    <span>
+      <!-- prettier-ignore -->
+      <svg in:fly={{ x: 5 }} class="w-6 h-6"
+		xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"/>
+			</svg>
+    </span>
+  {:else}
+    <span>
+      <!-- prettier-ignore -->
+      <svg in:fly={{ x: -5 }} class="h-6 w-6" 
+		xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/>
+      </svg>
+    </span>
+  {/if}
+</Button>

--- a/src/lib/components/ui/button/Button.svelte
+++ b/src/lib/components/ui/button/Button.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { VariantProps } from 'class-variance-authority';
+  import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
+  import { cn } from '$lib/utils';
+  import { buttonVariants } from '.';
+
+  let className: string | undefined | null = undefined;
+  export { className as class };
+  export let href: HTMLAnchorAttributes['href'] = undefined;
+  export let type: HTMLButtonAttributes['type'] = undefined;
+  export let variant: VariantProps<typeof buttonVariants>['variant'] = 'default';
+  export let size: VariantProps<typeof buttonVariants>['size'] = 'default';
+
+  type Props = {
+    class?: string | null;
+    variant?: VariantProps<typeof buttonVariants>['variant'];
+    size?: VariantProps<typeof buttonVariants>['size'];
+  };
+
+  interface AnchorElement extends Props, HTMLAnchorAttributes {
+    href?: HTMLAnchorAttributes['href'];
+    type?: never;
+  }
+
+  interface ButtonElement extends Props, HTMLButtonAttributes {
+    type?: HTMLButtonAttributes['type'];
+    href?: never;
+  }
+
+  type $$Props = AnchorElement | ButtonElement;
+</script>
+
+<svelte:element
+  this={href ? 'a' : 'button'}
+  type={href ? undefined : type}
+  {href}
+  class={cn(buttonVariants({ variant, size, className }))}
+  {...$$restProps}
+  on:click
+  on:change
+  on:keydown
+  on:keyup
+  on:mouseenter
+  on:mouseleave
+>
+  <slot />
+</svelte:element>

--- a/src/lib/components/ui/button/index.ts
+++ b/src/lib/components/ui/button/index.ts
@@ -1,0 +1,28 @@
+import { cva } from 'class-variance-authority';
+
+export { default as Button } from './Button.svelte';
+
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'underline-offset-4 hover:underline text-primary'
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);

--- a/src/lib/components/ui/separator/Separator.svelte
+++ b/src/lib/components/ui/separator/Separator.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import type { SeparatorRootProps } from 'radix-svelte';
+  import { Separator } from 'radix-svelte';
+  import { cn } from '$lib/utils';
+
+  let className: string | undefined | null = undefined;
+  export { className as class };
+
+  export let orientation: SeparatorRootProps['orientation'] = 'horizontal';
+  export let decorative: SeparatorRootProps['decorative'] = true;
+</script>
+
+<Separator.Root
+  {orientation}
+  {decorative}
+  class={cn(
+    'shrink-0 bg-border',
+    orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+    className
+  )}
+  {...$$restProps}
+/>

--- a/src/lib/components/ui/separator/index.ts
+++ b/src/lib/components/ui/separator/index.ts
@@ -1,0 +1,1 @@
+export { default as Separator } from './Separator.svelte';

--- a/src/lib/config/sanity/client.ts
+++ b/src/lib/config/sanity/client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/private';
 import { createClient } from '@sanity/client';
 
 import { sanityConfig } from './config';
+import type { SanityDocument } from 'sanity';
 
 export const previewClient = createClient({
   ...sanityConfig,
@@ -12,7 +13,7 @@ export const client = createClient(sanityConfig);
 export const getSanityServerClient = (usePreview: boolean) => (usePreview ? previewClient : client);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function overlayDrafts(docs: any[]): any[] {
+export function overlayDrafts<T extends SanityDocument>(docs: T[]): T[] {
   const documents = docs || [];
   const overlayed = documents.reduce((map, doc) => {
     if (!doc._id) {

--- a/src/lib/config/sanity/sanity.config.ts
+++ b/src/lib/config/sanity/sanity.config.ts
@@ -15,7 +15,8 @@ import {
   User,
   // objects
   Address,
-  Language
+  Language,
+  Skill
 } from '$lib/config/sanity/schemas';
 
 const singletonTypes = new Set<string>([User.name]);
@@ -37,14 +38,19 @@ export default defineConfig({
       User,
       // objects
       Address,
-      Language
+      Language,
+      Skill
     ],
     templates: (templates) => templates.filter(({ schemaType }) => !singletonTypes.has(schemaType))
   },
   plugins: [
     deskTool({
       defaultDocumentNode: (S, { schemaType }) => {
-        if (([User.name, Experience.name, Education.name] as string[]).includes(schemaType)) {
+        if (
+          ([User.name, Experience.name, Education.name, Project.name] as string[]).includes(
+            schemaType
+          )
+        ) {
           return S.document().views([
             S.view.form(),
             S.view.component(ResumePreview).title('Preview')

--- a/src/lib/config/sanity/schemas/company.ts
+++ b/src/lib/config/sanity/schemas/company.ts
@@ -16,7 +16,7 @@ export const Company = defineType({
     },
     {
       name: 'logo',
-      title: 'lOGO',
+      title: 'Logo',
       type: 'image',
       options: { hotspot: true },
       validation: (Rule) => Rule.required()

--- a/src/lib/config/sanity/schemas/experience.ts
+++ b/src/lib/config/sanity/schemas/experience.ts
@@ -2,6 +2,7 @@ import { defineType, type SanityDocument, type Reference, type PortableTextBlock
 import { BriefcaseIcon } from 'lucide-react';
 
 import type { Company } from './company';
+import type { Skill } from './objects';
 
 export const Experience = defineType({
   name: 'experience',
@@ -47,111 +48,25 @@ export const Experience = defineType({
       type: 'array',
       of: [
         {
-          type: 'string',
-          options: {
-            list: [
-              // Languages
-              'JavaScript',
-              'TypeScript',
-              'HTML',
-              'CSS',
-              'Python',
-              'Java',
-              'C#',
-              // Frameworks
-              'React',
-              'Next.js',
-              'Svelte',
-              'SvelteKit',
-              'Angular',
-              'Node.js',
-              'Express',
-              'NestJS',
-              // Style Libraries
-              'SCSS',
-              'Tailwind CSS',
-              'Material UI',
-              'Headless UI',
-              // Databases
-              'MongoDB',
-              'PostgreSQL',
-              'Redis',
-              // Tools
-              'GraphQL',
-              'Apollo',
-              // Cloud
-              'AWS',
-              'Docker',
-              'Podman',
-              'Terraform',
-              'Ansible',
-              'Kubernetes',
-              'Microservices',
-              // OS
-              'Linux',
-              'Ubuntu',
-              'Manjaro',
-              'Windows',
-              // Other
-              'Git',
-              'GitHub',
-              'GitLab',
-              'DevOps',
-              'CI/CD'
-            ]
-          }
+          type: 'skill'
         }
       ]
     }
-  ]
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      media: 'company.logo'
+    }
+  }
 });
 
 export type Experience = SanityDocument & {
   _type: (typeof Experience)['name'];
   title: string;
   company: Reference & { _def: Company };
-  startDate: string;
-  endDate?: string;
+  startDate: `${number}-${number}-${number}`;
+  endDate?: `${number}-${number}-${number}`;
   description?: PortableTextBlock[];
-  skills:
-    | 'JavaScript'
-    | 'TypeScript'
-    | 'HTML'
-    | 'CSS'
-    | 'Python'
-    | 'Java'
-    | 'C#'
-    | 'React'
-    | 'Next.js'
-    | 'Svelte'
-    | 'SvelteKit'
-    | 'Angular'
-    | 'Node.js'
-    | 'Express'
-    | 'NestJS'
-    | 'SCSS'
-    | 'Tailwind CSS'
-    | 'Material UI'
-    | 'Headless UI'
-    | 'MongoDB'
-    | 'PostgreSQL'
-    | 'Redis'
-    | 'GraphQL'
-    | 'Apollo'
-    | 'AWS'
-    | 'Docker'
-    | 'Podman'
-    | 'Terraform'
-    | 'Ansible'
-    | 'Kubernetes'
-    | 'Microservices'
-    | 'Linux'
-    | 'Ubuntu'
-    | 'Manjaro'
-    | 'Windows'
-    | 'Git'
-    | 'GitHub'
-    | 'GitLab'
-    | 'DevOps'
-    | 'CI/CD'[];
+  skills: Skill[];
 };

--- a/src/lib/config/sanity/schemas/objects/index.ts
+++ b/src/lib/config/sanity/schemas/objects/index.ts
@@ -1,2 +1,3 @@
 export { Address } from './address';
 export { Language } from './language';
+export { Skill } from './skill';

--- a/src/lib/config/sanity/schemas/objects/language.ts
+++ b/src/lib/config/sanity/schemas/objects/language.ts
@@ -1,20 +1,20 @@
 import { defineType, type TypedObject } from 'sanity';
 import { LanguagesIcon } from 'lucide-react';
 
-const LANGUAGES = [
-  { title: 'English', value: 'english' },
-  { title: 'Spanish', value: 'spanish' },
-  { title: 'French', value: 'french' },
-  { title: 'German', value: 'german' },
-  { title: 'Italian', value: 'italian' },
-  { title: 'Portuguese', value: 'portuguese' },
-  { title: 'Russian', value: 'russian' },
-  { title: 'Chinese', value: 'chinese' },
-  { title: 'Japanese', value: 'japanese' },
-  { title: 'Korean', value: 'korean' },
-  { title: 'Arabic', value: 'arabic' },
-  { title: 'Hindi', value: 'hindi' }
-] satisfies { title: string; value: string }[];
+export const LANGUAGES = [
+  'English',
+  'Spanish',
+  'French',
+  'German',
+  'Italian',
+  'Portuguese',
+  'Russian',
+  'Chinese',
+  'Japanese',
+  'Korean',
+  'Arabic',
+  'Hindi'
+];
 
 export const Language = defineType({
   name: 'language',
@@ -49,8 +49,8 @@ export const Language = defineType({
     },
     prepare({ language, native }) {
       return {
-        title: language && LANGUAGES.find((lang) => lang.value === language)?.title,
-        subtitle: native ? 'Native' : 'Not Native'
+        title: language,
+        subtitle: native ? 'Native' : ''
       };
     }
   }
@@ -59,17 +59,17 @@ export const Language = defineType({
 export type Language = TypedObject & {
   _type: (typeof Language)['name'];
   language:
-    | 'english'
-    | 'spanish'
-    | 'french'
-    | 'german'
-    | 'italian'
-    | 'portuguese'
-    | 'russian'
-    | 'chinese'
-    | 'japanese'
-    | 'korean'
-    | 'arabic'
-    | 'hindi';
+    | 'English'
+    | 'Spanish'
+    | 'French'
+    | 'German'
+    | 'Italian'
+    | 'Portuguese'
+    | 'Russian'
+    | 'Chinese'
+    | 'Japanese'
+    | 'Korean'
+    | 'Arabic'
+    | 'Hindi';
   native: boolean;
 };

--- a/src/lib/config/sanity/schemas/objects/skill.ts
+++ b/src/lib/config/sanity/schemas/objects/skill.ts
@@ -1,0 +1,134 @@
+import { defineType } from 'sanity';
+import { CheckIcon } from 'lucide-react';
+
+export const SKILLS = [
+  // Languages
+  'JavaScript',
+  'TypeScript',
+  'TypeScript, JavaScript',
+  'HTML',
+  'CSS',
+  'HTML, CSS',
+  'TypeScript, HTML, CSS',
+  'Python',
+  'Java',
+  'C#',
+  'SQL',
+  'Scripting',
+  // Frameworks
+  'React',
+  'Next.js',
+  'React, Next.js',
+  'Svelte',
+  'SvelteKit',
+  'Svelte, SvelteKit',
+  'Angular',
+  'Flask',
+  'Python, Flask',
+  'Node.js',
+  'Express',
+  'NestJS',
+  'Node.js, Nestjs',
+  // Style Libraries
+  'SCSS',
+  'Tailwind CSS',
+  'Material UI',
+  'Shadcn UI',
+  // Databases
+  'Database Management',
+  'MongoDB',
+  'PostgreSQL',
+  'Redis',
+  'Pub/Sub',
+  'Redis, Pub/Sub',
+  // Tools
+  'GraphQL',
+  'Apollo',
+  'Urql',
+  'gRPC',
+  'Unity',
+  // Cloud
+  'AWS',
+  'Docker',
+  'Podman',
+  'Microservices',
+  'Hashicorp Terraform',
+  'Ansible',
+  'Kubernetes',
+  'Vercel',
+  // OS
+  'Linux',
+  'Ubuntu',
+  'Manjaro',
+  'Windows',
+  // Other
+  'Git',
+  'GitHub',
+  'GitLab',
+  'GitHub/GitLab',
+  'DevOps',
+  'CI/CD',
+  'DevOps, CI/CD',
+  'Automation',
+  'Network Management',
+  // Qualities
+  'Teamwork',
+  'Communication',
+  'Problem Solving',
+  'Critical Thinking',
+  'Leadership',
+  'Time Management',
+  'Organization'
+];
+
+export const Skill = defineType({
+  name: 'skill',
+  title: 'Skill',
+  type: 'string',
+  icon: CheckIcon,
+  options: {
+    list: SKILLS
+  }
+});
+
+export type Skill =
+  | 'JavaScript'
+  | 'TypeScript'
+  | 'HTML'
+  | 'CSS'
+  | 'Python'
+  | 'Java'
+  | 'C#'
+  | 'React'
+  | 'Next.js'
+  | 'Svelte'
+  | 'SvelteKit'
+  | 'Angular'
+  | 'Node.js'
+  | 'Express'
+  | 'NestJS'
+  | 'SCSS'
+  | 'Tailwind CSS'
+  | 'Material UI'
+  | 'Headless UI'
+  | 'MongoDB'
+  | 'PostgreSQL'
+  | 'Redis'
+  | 'GraphQL'
+  | 'Apollo'
+  | 'AWS'
+  | 'Docker'
+  | 'Podman'
+  | 'Terraform'
+  | 'Ansible'
+  | 'Kubernetes'
+  | 'Microservices'
+  | 'Linux'
+  | 'Ubuntu'
+  | 'Manjaro'
+  | 'Windows'
+  | 'Git'
+  | 'GitHub'
+  | 'GitLab'
+  | 'DevOps'
+  | 'CI/CD';

--- a/src/lib/config/sanity/schemas/project.ts
+++ b/src/lib/config/sanity/schemas/project.ts
@@ -1,6 +1,8 @@
 import { defineType, type SanityDocument, type PortableTextBlock, type Reference } from 'sanity';
 import { CodeIcon } from 'lucide-react';
+
 import type { Company } from './company';
+import type { Skill } from './objects';
 
 export const Project = defineType({
   name: 'project',
@@ -32,64 +34,18 @@ export const Project = defineType({
       type: 'url'
     },
     {
+      name: 'startDate',
+      title: 'Start Date',
+      type: 'date',
+      validation: (rule) => rule.required()
+    },
+    {
       name: 'skills',
       title: 'Skills',
       type: 'array',
       of: [
         {
-          type: 'string',
-          options: {
-            list: [
-              // Languages
-              'JavaScript',
-              'TypeScript',
-              'HTML',
-              'CSS',
-              'Python',
-              'Java',
-              'C#',
-              // Frameworks
-              'React',
-              'Next.js',
-              'Svelte',
-              'SvelteKit',
-              'Angular',
-              'Node.js',
-              'Express',
-              'NestJS',
-              // Style Libraries
-              'SCSS',
-              'Tailwind CSS',
-              'Material UI',
-              'Headless UI',
-              // Databases
-              'MongoDB',
-              'PostgreSQL',
-              'Redis',
-              // Tools
-              'GraphQL',
-              'Apollo',
-              // Cloud
-              'AWS',
-              'Docker',
-              'Podman',
-              'Terraform',
-              'Ansible',
-              'Kubernetes',
-              'Microservices',
-              // OS
-              'Linux',
-              'Ubuntu',
-              'Manjaro',
-              'Windows',
-              // Other
-              'Git',
-              'GitHub',
-              'GitLab',
-              'DevOps',
-              'CI/CD'
-            ]
-          }
+          type: 'skill'
         }
       ]
     }
@@ -102,45 +58,5 @@ export type Project = SanityDocument & {
   company: Reference & { _def: Company };
   description: PortableTextBlock[];
   link?: string;
-  skills:
-    | 'JavaScript'
-    | 'TypeScript'
-    | 'HTML'
-    | 'CSS'
-    | 'Python'
-    | 'Java'
-    | 'C#'
-    | 'React'
-    | 'Next.js'
-    | 'Svelte'
-    | 'SvelteKit'
-    | 'Angular'
-    | 'Node.js'
-    | 'Express'
-    | 'NestJS'
-    | 'SCSS'
-    | 'Tailwind CSS'
-    | 'Material UI'
-    | 'Headless UI'
-    | 'MongoDB'
-    | 'PostgreSQL'
-    | 'Redis'
-    | 'GraphQL'
-    | 'Apollo'
-    | 'AWS'
-    | 'Docker'
-    | 'Podman'
-    | 'Terraform'
-    | 'Ansible'
-    | 'Kubernetes'
-    | 'Microservices'
-    | 'Linux'
-    | 'Ubuntu'
-    | 'Manjaro'
-    | 'Windows'
-    | 'Git'
-    | 'GitHub'
-    | 'GitLab'
-    | 'DevOps'
-    | 'CI/CD'[];
+  skills: Skill[];
 };

--- a/src/lib/config/sanity/schemas/types.ts
+++ b/src/lib/config/sanity/schemas/types.ts
@@ -1,4 +1,4 @@
-import type { Reference } from '@sanity/types';
+import type { Reference } from 'sanity';
 
 /**
  * Resolves the type of a Reference to the referenced type.

--- a/src/lib/config/sanity/schemas/user.ts
+++ b/src/lib/config/sanity/schemas/user.ts
@@ -1,7 +1,7 @@
 import { defineType, type SanityDocument, type Image, type PortableTextBlock } from 'sanity';
 import { UserIcon } from 'lucide-react';
 
-import type { Address, Language } from './objects';
+import type { Address, Language, Skill } from './objects';
 
 export const User = defineType({
   name: 'user',
@@ -71,16 +71,22 @@ export const User = defineType({
       ]
     },
     {
+      name: 'languages',
+      title: 'Languages',
+      type: 'array',
+      of: [{ type: 'language' }]
+    },
+    {
       name: 'interests',
       title: 'Interests',
       type: 'array',
       of: [{ type: 'string' }]
     },
     {
-      name: 'languages',
-      title: 'Languages',
+      name: 'skills',
+      title: 'Skills',
       type: 'array',
-      of: [{ type: 'language' }]
+      of: [{ type: 'skill' }]
     }
   ],
   preview: {
@@ -105,6 +111,7 @@ export type User = SanityDocument & {
     github?: string;
     linkedin?: string;
   };
-  interests: string[];
   languages: Language[];
+  interests: string[];
+  skills: Skill[];
 };

--- a/src/lib/config/sanity/sveltekit/previewSubscriptionStore.ts
+++ b/src/lib/config/sanity/sveltekit/previewSubscriptionStore.ts
@@ -81,9 +81,7 @@ function querySubscription<R = any>(options: {
   const params = writable<Params>(options.params);
 
   onMount(() => {
-    if (!enabled) {
-      return;
-    }
+    if (!enabled) return;
 
     loading.set(true);
 
@@ -92,9 +90,7 @@ function querySubscription<R = any>(options: {
 
     getCurrentUser(projectId, aborter, token)
       .then((user) => {
-        if (user) {
-          return;
-        }
+        if (user) return;
 
         // eslint-disable-next-line no-console
         console.warn('Not authenticated - preview not available');
@@ -114,9 +110,7 @@ function querySubscription<R = any>(options: {
       .finally(() => loading.set(false));
 
     return () => {
-      if (subscription) {
-        subscription.unsubscribe();
-      }
+      if (subscription) subscription.unsubscribe();
 
       aborter.abort();
     };

--- a/src/routes/(app)/resume/+page.server.ts
+++ b/src/routes/(app)/resume/+page.server.ts
@@ -1,5 +1,35 @@
-import type { PageServerLoad } from './$types';
+import groq from 'groq';
 
-export const load = (async () => {
-  return {};
-}) satisfies PageServerLoad;
+import { getSanityServerClient, overlayDrafts } from '$lib/config/sanity/client';
+import type { Education, Experience, Project, User } from '$lib/config/sanity/schemas';
+import type { Resolved } from '$lib/config/sanity/schemas/types';
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ parent }) {
+  const { previewMode } = await parent();
+
+  const { user, experiences, education, projects } = await getSanityServerClient(previewMode)
+    .fetch<{
+    user: User;
+    experiences: (Experience & { company: Resolved<Experience['company']> })[];
+    education: Education[];
+    projects: (Project & { company: Resolved<Project['company']> })[];
+  }>(groq`
+    {
+      'user': *[_type == "user"] | order(_updatedAt desc) [0],
+      'experiences': *[_type == "experience"] { ..., company-> } | order(startDate desc, _updatedAt desc),
+      'education': *[_type == "education"] | order(startDate desc, _updatedAt desc),
+      'projects': *[_type == "project"] { ..., company-> } | order(startDate desc, _updatedAt desc)
+    }
+  `);
+
+  return {
+    previewMode,
+    initialData: {
+      user,
+      experiences: overlayDrafts(experiences),
+      education: overlayDrafts(education),
+      projects: overlayDrafts(projects)
+    }
+  };
+}

--- a/src/routes/(app)/resume/+page.svelte
+++ b/src/routes/(app)/resume/+page.svelte
@@ -1,5 +1,255 @@
 <script lang="ts">
+  import { PortableText } from '@portabletext/svelte';
+  import { GithubIcon, Globe2Icon, LinkedinIcon, MailIcon, PhoneIcon } from 'lucide-svelte';
+  import groq from 'groq';
+  import clsx from 'clsx';
+
+  import { Avatar, AvatarFallback, AvatarImage } from '$components/ui/avatar';
+  import { Separator } from '$components/ui/separator';
+  import { previewSubscription, urlForImage } from '$lib/config/sanity';
+
   import type { PageData } from './$types';
 
   export let data: PageData;
+
+  $: ({ initialData, previewMode } = data);
+  $: ({ data: liveData } = previewSubscription(
+    groq`
+    {
+      'user': *[_type == "user"] | order(_updatedAt desc) [0],
+      'experiences': *[_type == "experience"] { ..., company-> } | order(startDate desc, _updatedAt desc),
+      'education': *[_type == "education"] | order(startDate desc, _updatedAt desc),
+      'project': *[_type == "project"] { ..., company-> } | order(startDate desc, _updatedAt desc)
+    }
+  `,
+    {
+      initialData,
+      enabled: !!previewMode
+    }
+  ));
+
+  $: ({ user, experiences, education, projects } = $liveData);
+  $: imageUrl = urlForImage(user?.picture).width(408).height(408).url();
+  $: blurUrl = urlForImage(user?.picture).width(408).height(408).blur(100).url();
 </script>
+
+<svelte:head>
+  <title>{$liveData?.user?.name} | Resume</title>
+</svelte:head>
+
+<div class="container">
+  <section class="rounded overflow-hidden m-4 border shadow max-w-[960px] mx-auto">
+    <header class="bg-secondary dark:bg-black py-6 flex flex-col items-center justify-center gap-1">
+      <h1 class="text-4xl font-bold">{user.name}</h1>
+      <p>{user.title}</p>
+    </header>
+    <div class="grid grid-cols-[30%_70%]">
+      <!-- Sidebar -->
+      <aside class="p-4 bg-purple-400/50">
+        <Avatar class="w-40 h-40 mx-auto mb-6 shadow z-10 border-foreground border-2">
+          <AvatarImage src={imageUrl} alt="Jake Brazelton" />
+          <AvatarFallback>
+            <img src={blurUrl} alt="Jake Brazelton" />
+          </AvatarFallback>
+        </Avatar>
+        <Separator class="mb-6" />
+        <!-- Links -->
+        <div class="w-full mb-6 space-y-2">
+          <a
+            href="https://jakebrazelton.com"
+            class="w-6 h-6 flex items-center gap-2 text-sm whitespace-nowrap hover:cursor-pointer hover:underline"
+          >
+            <Globe2Icon class="w-5 h-5 shrink-0 stroke-foreground" />
+            jakebrazelton.com
+          </a>
+          <a
+            href={'mailto:' + user?.email}
+            class="w-6 h-6 flex items-center gap-2 text-sm whitespace-nowrap hover:cursor-pointer hover:underline"
+          >
+            <MailIcon
+              class="w-5 h-5 shrink-0 transition-colors fill-foreground stroke-[#dfc1fd] dark:stroke-[#614586] dark:fill-foreground"
+            />
+            {user?.email}
+          </a>
+          <a
+            href={'tel:+1' + user?.phone.replaceAll(/[^0-9]/g, '')}
+            class="w-6 h-6 flex items-center gap-2 text-sm whitespace-nowrap hover:cursor-pointer hover:underline"
+          >
+            <PhoneIcon
+              class="w-5 h-5 shrink-0 fill-foreground dark:stroke-none dark:fill-foreground"
+            />
+            {user?.phone}
+          </a>
+          {#if user?.links?.github}
+            <a
+              href={user?.links?.github}
+              class="w-6 h-6 flex items-center gap-2 text-sm whitespace-nowrap hover:cursor-pointer hover:underline"
+            >
+              <GithubIcon
+                class="w-5 h-5 shrink-0 stroke-foreground fill-foreground dark:stroke-foreground dark:fill-foreground"
+              />
+              {user?.links?.github.replace(/https:\/\/(www\.)?/i, '')}
+            </a>
+          {/if}
+          {#if user?.links?.linkedin}
+            <a
+              href={user?.links?.linkedin}
+              class="w-6 h-6 flex items-center gap-2 text-sm whitespace-nowrap hover:cursor-pointer hover:underline"
+            >
+              <LinkedinIcon
+                class="w-5 h-5 shrink-0 stroke-foreground fill-foreground dark:stroke-foreground dark:fill-foreground"
+              />
+              {user?.links?.linkedin.replace(/https:\/\/(www\.)?/i, '')}
+            </a>
+          {/if}
+        </div>
+        <!-- Languages -->
+        <div class="w-full text-start mb-6">
+          <p class="text-lg font-bold mb-2">Languages</p>
+          <ul>
+            {#each user?.languages ?? [] as { language, native }}
+              <li class="mb-1">
+                {language}
+                {#if native}
+                  <p class="inline ml-1 text-foreground/75">(Native)</p>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        </div>
+        <!-- Interests -->
+        <div class="w-full text-start mb-6">
+          <p class="text-lg font-bold mb-2">Interests</p>
+          <ul class="space-y-2">
+            {#each user?.interests ?? [] as interest}
+              <li>{interest}</li>
+            {/each}
+          </ul>
+        </div>
+        <!-- Skills -->
+        <div class="w-full text-start mb-6">
+          <p class="text-lg font-bold mb-2">Skills</p>
+          <ul class="space-y-2">
+            {#each user?.skills ?? [] as skill}
+              <li>{skill}</li>
+            {/each}
+          </ul>
+        </div>
+      </aside>
+      <!-- Main Block -->
+      <section class="p-6 dark:bg-secondary space-y-6">
+        <!-- Experiences -->
+        <div class="w-full text-start">
+          <h2 class="text-xl font-bold uppercase tracking-wider">Experiences</h2>
+          <Separator class="mb-4" />
+          <ul class="space-y-6">
+            {#each experiences ?? [] as experience}
+              <li>
+                <div class="flex mb-2">
+                  <span>
+                    <p class="text-lg leading-snug font-semibold">{experience.title}</p>
+                    <a
+                      href={experience.company.website}
+                      class="text-sm text-foreground/75 hover:cursor-pointer hover:underline"
+                      >{experience.company.name}</a
+                    >
+                  </span>
+                  <p class="inline text-sm text-foreground/75 ml-auto">
+                    {#if !experience.endDate}
+                      {new Date(experience.startDate).getFullYear()} - Present
+                    {:else if experience.startDate.split('-')[0] === experience.endDate.split('-')[0]}
+                      {new Date(experience.startDate).getFullYear()}
+                    {:else}
+                      {new Date(experience.startDate).getFullYear()} - {new Date(
+                        experience.endDate
+                      ).getFullYear()}
+                    {/if}
+                  </p>
+                </div>
+                <div class="contents text-sm">
+                  <PortableText value={experience.description} />
+                </div>
+                <ul class="flex gap-2 flex-wrap mt-2">
+                  {#each experience?.skills ?? [] as skill}
+                    <li class="bg-accent px-3 py-[0.2rem] text-sm rounded-full">{skill}</li>
+                  {/each}
+                </ul>
+              </li>
+            {/each}
+          </ul>
+        </div>
+        <!-- Education -->
+        <div class="w-full text-start">
+          <h2 class="text-xl font-bold uppercase tracking-wider">Education</h2>
+          <Separator class="mb-4" />
+          <ul class="space-y-4">
+            {#each education ?? [] as degree}
+              <li>
+                <div class="flex mb-2">
+                  <span>
+                    <p class="text-lg leading-snug font-semibold">{degree.degree}</p>
+                    <p class="text-sm text-foreground/75">
+                      {degree.school}
+                    </p>
+                  </span>
+                  <p class="inline text-sm text-foreground/75 ml-auto">
+                    {#if !degree.endDate}
+                      {new Date(degree.startDate).getFullYear()} - Present
+                    {:else if degree.startDate.split('-')[0] === degree.endDate.split('-')[0]}
+                      {new Date(degree.startDate).getFullYear()}
+                    {:else}
+                      {new Date(degree.startDate).getFullYear()} - {new Date(
+                        degree.endDate
+                      ).getFullYear()}
+                    {/if}
+                  </p>
+                </div>
+                <p class="list-item text-sm text-foreground/75 before:content-['•'] before:mr-1">
+                  {degree.note}
+                </p>
+              </li>
+            {/each}
+          </ul>
+        </div>
+        <!-- Projects -->
+        <div class="w-full text-start">
+          <h2 class="text-xl font-bold uppercase tracking-wider">Projects</h2>
+          <Separator class="mb-4" />
+          <ul class="space-y-4">
+            {#each projects ?? [] as project}
+              <li>
+                <div class="flex flex-col items-start mb-2">
+                  <svelte:element
+                    this={project.link ? 'a' : 'p'}
+                    href={project.link}
+                    class={clsx('text-lg leading-snug font-semibold', {
+                      'hover:cursor-pointer hover:underline': project.link
+                    })}
+                  >
+                    {project.name}
+                  </svelte:element>
+                  {#if project.company}
+                    <a
+                      href={project.company.website}
+                      class="text-sm text-foreground/75 hover:cursor-pointer hover:underline"
+                    >
+                      {project.company.name}
+                    </a>
+                  {/if}
+                </div>
+                <div class="contents text-sm">
+                  <PortableText value={project.description} />
+                </div>
+                <ul class="flex gap-2 flex-wrap mt-2">
+                  {#each project?.skills ?? [] as skill}
+                    <li class="bg-accent px-3 py-[0.2rem] text-sm rounded-full">{skill}</li>
+                  {/each}
+                </ul>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      </section>
+    </div>
+  </section>
+</div>

--- a/src/routes/api/preview/+server.ts
+++ b/src/routes/api/preview/+server.ts
@@ -20,7 +20,7 @@ export const GET: RequestHandler = async ({ url, cookies, setHeaders }) => {
   let isPreviewing = false;
 
   // Our query may vary depending on the type.
-  if (type === 'user') {
+  if (['user', 'experience', 'education', 'project'].includes(type)) {
     isPreviewing = true;
 
     // Set the redirect path and append the isPreview query


### PR DESCRIPTION
This MR adds the path `/resume` and configures the page to host a PDF look-alike of a resume backed by Sanity.

Resolves #6 